### PR TITLE
Adjusting decks to show only two regions

### DIFF
--- a/frontend/src/components/Form/SectionParticipantes/FormularioParticipante/index.js
+++ b/frontend/src/components/Form/SectionParticipantes/FormularioParticipante/index.js
@@ -1,228 +1,232 @@
-import React, {useState, useEffect} from 'react';
-import {DeckEncoder} from 'runeterra';
+import React, { useState, useEffect } from 'react';
+import { DeckEncoder } from 'runeterra';
 
-import {useSaveState} from '../../../../context/SaveState';
+import { useSaveState } from '../../../../context/SaveState';
 
 import JanelaErro from '../../JanelaErro';
-import {Barra, Campo, Botoes, Botao} from './style';
+import { Barra, Campo, Botoes, Botao } from './style';
 
 import factions from '../../../../assets/factions.json';
 import champions from '../../../../assets/champions.json';
 
-function renderTime(time, index){
-	return <option key={index} value={time.nome}>{time.nome}</option>;
+function renderTime(time, index) {
+  return <option key={index} value={time.nome}>{time.nome}</option>;
 }
 
-const FormularioParticipante = ({titulo, mensagemClica, regraFuncao, mostrar, setMostrar, jogadorAntigo}) => {
+const FormularioParticipante = ({ titulo, mensagemClica, regraFuncao, mostrar, setMostrar, jogadorAntigo }) => {
 
-	const { saveState, setSaveState } = useSaveState();
-	const { regra, jogadores, times } = saveState;
+  const { saveState, setSaveState } = useSaveState();
+  const { regra, jogadores, times } = saveState;
 
-	const [ jogador, setJogador ] = useState({nome: '',
-		time: {nome: '', url_logo: ''},
-		decks: [{code: '', regions: [], champions: []},
-				{code: '', regions: [], champions: []},
-				{code: '', regions: [], champions: []}]});
-	const [ erros, setErros ] = useState([]);
+  const [jogador, setJogador] = useState({
+    nome: '',
+    time: { nome: '', url_logo: '' },
+    decks: [{ code: '', regions: [], champions: [] },
+    { code: '', regions: [], champions: [] },
+    { code: '', regions: [], champions: [] }]
+  });
+  const [erros, setErros] = useState([]);
 
-	useEffect(() => {
-		function carregaJogador(){
-			if (mostrar){
-				setJogador(jogadorAntigo);
-			}
-		}
-		carregaJogador();
-	}, [mostrar, jogadorAntigo]);
+  useEffect(() => {
+    function carregaJogador() {
+      if (mostrar) {
+        setJogador(jogadorAntigo);
+      }
+    }
+    carregaJogador();
+  }, [mostrar, jogadorAntigo]);
 
-	function buscaTime(nome){
-		return times.find((time) => time.nome === nome);
-	}
+  function buscaTime(nome) {
+    return times.find((time) => time.nome === nome);
+  }
 
-	function buscaJogador(nome){
-		return jogadores.find((jogador) => jogador.nome === nome);
-	}
+  function buscaJogador(nome) {
+    return jogadores.find((jogador) => jogador.nome === nome);
+  }
 
-	function mudaTime(nome){
-		const time = buscaTime(nome);
-		if (time)	setJogador({...jogador, time});
-		else		setJogador({...jogador, time: {nome: '', url_logo: ''}});
-	}
+  function mudaTime(nome) {
+    const time = buscaTime(nome);
+    if (time) setJogador({ ...jogador, time });
+    else setJogador({ ...jogador, time: { nome: '', url_logo: '' } });
+  }
 
-	function mudaCodigoDeck(deck, index){
-		const novo = [...jogador.decks];
-		novo[index].code = deck;
-		setJogador({...jogador, decks: novo});
-	}
+  function mudaCodigoDeck(deck, index) {
+    const novo = [...jogador.decks];
+    novo[index].code = deck;
+    setJogador({ ...jogador, decks: novo });
+  }
 
-	function pegaRegioes(cards){
+  function pegaRegioes(cards) {
     let cardsPerRegion = {};
-		cards.forEach((card) => {
-			const region = card.faction.shortCode;
-      if (!cardsPerRegion.hasOwnProperty(region)){
+    cards.forEach((card) => {
+      const region = card.faction.shortCode;
+      if (!cardsPerRegion.hasOwnProperty(region)) {
         cardsPerRegion[region] = 0
       }
       cardsPerRegion[region] = cardsPerRegion[region] += 1
-		});
+    });
 
     let allRegions = Object.keys(cardsPerRegion).map((region) => [region, cardsPerRegion[region]]);
-		let deckRegions = allRegions
-      .sort((a,b) => (b[1] - a[1]))
-      .slice(0,2)
+    let deckRegions = allRegions
+      .sort((a, b) => (b[1] - a[1]))
+      .slice(0, 2)
       .map((region) => factions[region[0]]);
- 
-    console.log(factions)
 
-		return deckRegions;
-	}
+    return deckRegions;
+  }
 
-	function pegaCampeoes(cards){
-		let campeoes = [];
-		cards.forEach((card) => {
-			if (champions[card.code] !== undefined){
-				campeoes.push({
-					nome: champions[card.code],
-					qtd: card.count
-				});
-			}
-		});
-		campeoes.sort();
-		return campeoes;
-	}
-	
-	function decodeDecks(decks){
-		return decks.map(({code}) => {
-			if (code === ''){
-				return undefined;
-			}
+  function pegaCampeoes(cards) {
+    let campeoes = [];
+    cards.forEach((card) => {
+      if (champions[card.code] !== undefined) {
+        campeoes.push({
+          nome: champions[card.code],
+          qtd: card.count
+        });
+      }
+    });
+    campeoes.sort();
+    return campeoes;
+  }
 
-			let cards = [];
+  function decodeDecks(decks) {
+    return decks.map(({ code }) => {
+      if (code === '') {
+        return undefined;
+      }
 
-			try{
-				cards = DeckEncoder.decode(code);
-			}catch (e){
+      let cards = [];
+
+      try {
+        cards = DeckEncoder.decode(code);
+      } catch (e) {
         console.log(e)
-				return undefined;
-			}
+        return undefined;
+      }
 
-			return {code: code, cards: cards, regions: pegaRegioes(cards), champions: pegaCampeoes(cards)};
-		});
-	}
+      return { code: code, cards: cards, regions: pegaRegioes(cards), champions: pegaCampeoes(cards) };
+    });
+  }
 
-	function decksValidos(decks){
-		return decks.filter((deck) => deck === undefined).length === 0;
-	}
+  function decksValidos(decks) {
+    return decks.filter((deck) => deck === undefined).length === 0;
+  }
 
-	function segueRegra(decks){
-		return !regra || regraFuncao[regra](decks);
-	}
+  function segueRegra(decks) {
+    return !regra || regraFuncao[regra](decks);
+  }
 
-	function geraLinkDetalhes(){
-		let url = `https://xtecna.github.io/lor-deck-checker/index.html?` +
-				  `regra=${regra.toLowerCase()}&` +
-				  `singleton=false`;
-		jogador.decks.forEach((deck, index) => url += `&deck${index + 1}=${deck.code}`);
-		return url;
-	}
+  function geraLinkDetalhes() {
+    let url = `https://xtecna.github.io/lor-deck-checker/index.html?` +
+      `regra=${regra.toLowerCase()}&` +
+      `singleton=false`;
+    jogador.decks.forEach((deck, index) => url += `&deck${index + 1}=${deck.code}`);
+    return url;
+  }
 
-	function atualizaNovoJogador(novo_jogador, jogador){
-		return (jogador.nome === jogadorAntigo.nome) ? novo_jogador : jogador;
-	}
+  function atualizaNovoJogador(novo_jogador, jogador) {
+    return (jogador.nome === jogadorAntigo.nome) ? novo_jogador : jogador;
+  }
 
-	function saveOrUpdateJogador(jogador){
-		const novoErros = [];
+  function saveOrUpdateJogador(jogador) {
+    const novoErros = [];
 
-		if (jogador.nome && (jogador.time.nome === '' || buscaTime(jogador.time.nome))){
-			if (!mostrar && buscaJogador(jogador.nome)){
-				novoErros.push({mensagem: 'Já existe um jogador com esse nome.'});
-			}
+    if (jogador.nome && (jogador.time.nome === '' || buscaTime(jogador.time.nome))) {
+      if (!mostrar && buscaJogador(jogador.nome)) {
+        novoErros.push({ mensagem: 'Já existe um jogador com esse nome.' });
+      }
 
-			const novosDecks = decodeDecks(jogador.decks);
+      const novosDecks = decodeDecks(jogador.decks);
 
-			if (!decksValidos(novosDecks)){
-				novoErros.push({mensagem: 'Algum código de deck passado é inválido.'});
-				setErros(novoErros);
-				return;
-			}
+      if (!decksValidos(novosDecks)) {
+        novoErros.push({ mensagem: 'Algum código de deck passado é inválido.' });
+        setErros(novoErros);
+        return;
+      }
 
-			if (!segueRegra(novosDecks)){
-				novoErros.push({
-					mensagem: 'Os decks passados não seguem as regras estabelecidas.',
-					detalhes: geraLinkDetalhes()
-				});
-			}
+      if (!segueRegra(novosDecks)) {
+        novoErros.push({
+          mensagem: 'Os decks passados não seguem as regras estabelecidas.',
+          detalhes: geraLinkDetalhes()
+        });
+      }
 
-			if (novoErros.length > 0){
-				setErros(novoErros);
-				return;
-			}
+      if (novoErros.length > 0) {
+        setErros(novoErros);
+        return;
+      }
 
-			novosDecks.forEach((deck, index) => {
-				const novo = [...jogador.decks];
-				novo[index].code = deck.code;
-				novo[index].regions = deck.regions;
-				novo[index].champions = deck.champions;
-				setJogador({...jogador, decks: novo});
-			});
-			
-			if (mostrar){
-				setSaveState({...saveState,
-					jogador1: atualizaNovoJogador(jogador, saveState.jogador1),
-					jogador2: atualizaNovoJogador(jogador, saveState.jogador2),
-					partidas: saveState.partidas.map((partida) => {
-						return {...partida,
-							jogador1: atualizaNovoJogador(jogador, partida.jogador1),
-							jogador2: atualizaNovoJogador(jogador, partida.jogador2)
-						};
-					}),
-					jogadores: saveState.jogadores.map((j) => atualizaNovoJogador(jogador, j))
-				});
-			}else{
-				setSaveState({...saveState, jogadores: [...jogadores, jogador]});
-			}
+      novosDecks.forEach((deck, index) => {
+        const novo = [...jogador.decks];
+        novo[index].code = deck.code;
+        novo[index].regions = deck.regions;
+        novo[index].champions = deck.champions;
+        setJogador({ ...jogador, decks: novo });
+      });
 
-			setJogador({nome: '',
-				time: {nome: '', url_logo: ''},
-				decks: [{code: '', regions: [], champions: []},
-						{code: '', regions: [], champions: []},
-						{code: '', regions: [], champions: []}]});
-			if (mostrar)	setMostrar(false);
-		}else{
-			novoErros.push({mensagem: 'Nome ou time inválido.'});
-		}
-		
-		setErros(novoErros);
-	}
-	
-	return (
-		<>
-			<h3>{titulo}</h3>
-			<Campo>
-				<label htmlFor="time_jogador">Time:</label>
-				<select name="time_jogador" value={jogador.time.nome}
-						onChange={(e) => mudaTime(e.target.value)}>
-					<option value="">-</option>
-					{times.map(renderTime)}
-				</select>
-			</Campo>
-			<Campo>
-				<label htmlFor="nome_jogador">Nome:</label>
-				<Barra type="text" name="nome_jogador" value={jogador.nome}
-					   onChange={(e) => setJogador({...jogador, nome: e.target.value})}></Barra>
-			</Campo>
-			{jogador.decks.map(({code}, index) => {
-				return <Campo key={index}>
-					<label htmlFor={`deck${index+1}`}>Deck {index+1}:</label>
-					<Barra type="text" name={`deck${index+1}`} value={code}
-						   onChange={(e) => mudaCodigoDeck(e.target.value, index)}></Barra>
-				</Campo>
-			})}
-			{erros.length > 0 && <JanelaErro erros={erros} setErros={setErros}/>}
-			<Botoes>
-				<Botao onClick={() => saveOrUpdateJogador(jogador)}>{mensagemClica}</Botao>
-				{mostrar && <Botao onClick={() => setMostrar(false)}>Cancelar edição</Botao>}
-			</Botoes>
-		</>
-	);
+      if (mostrar) {
+        setSaveState({
+          ...saveState,
+          jogador1: atualizaNovoJogador(jogador, saveState.jogador1),
+          jogador2: atualizaNovoJogador(jogador, saveState.jogador2),
+          partidas: saveState.partidas.map((partida) => {
+            return {
+              ...partida,
+              jogador1: atualizaNovoJogador(jogador, partida.jogador1),
+              jogador2: atualizaNovoJogador(jogador, partida.jogador2)
+            };
+          }),
+          jogadores: saveState.jogadores.map((j) => atualizaNovoJogador(jogador, j))
+        });
+      } else {
+        setSaveState({ ...saveState, jogadores: [...jogadores, jogador] });
+      }
+
+      setJogador({
+        nome: '',
+        time: { nome: '', url_logo: '' },
+        decks: [{ code: '', regions: [], champions: [] },
+        { code: '', regions: [], champions: [] },
+        { code: '', regions: [], champions: [] }]
+      });
+      if (mostrar) setMostrar(false);
+    } else {
+      novoErros.push({ mensagem: 'Nome ou time inválido.' });
+    }
+
+    setErros(novoErros);
+  }
+
+  return (
+    <>
+      <h3>{titulo}</h3>
+      <Campo>
+        <label htmlFor="time_jogador">Time:</label>
+        <select name="time_jogador" value={jogador.time.nome}
+          onChange={(e) => mudaTime(e.target.value)}>
+          <option value="">-</option>
+          {times.map(renderTime)}
+        </select>
+      </Campo>
+      <Campo>
+        <label htmlFor="nome_jogador">Nome:</label>
+        <Barra type="text" name="nome_jogador" value={jogador.nome}
+          onChange={(e) => setJogador({ ...jogador, nome: e.target.value })}></Barra>
+      </Campo>
+      {jogador.decks.map(({ code }, index) => {
+        return <Campo key={index}>
+          <label htmlFor={`deck${index + 1}`}>Deck {index + 1}:</label>
+          <Barra type="text" name={`deck${index + 1}`} value={code}
+            onChange={(e) => mudaCodigoDeck(e.target.value, index)}></Barra>
+        </Campo>
+      })}
+      {erros.length > 0 && <JanelaErro erros={erros} setErros={setErros} />}
+      <Botoes>
+        <Botao onClick={() => saveOrUpdateJogador(jogador)}>{mensagemClica}</Botao>
+        {mostrar && <Botao onClick={() => setMostrar(false)}>Cancelar edição</Botao>}
+      </Botoes>
+    </>
+  );
 };
 
 export default FormularioParticipante;

--- a/frontend/src/components/Form/SectionParticipantes/FormularioParticipante/index.js
+++ b/frontend/src/components/Form/SectionParticipantes/FormularioParticipante/index.js
@@ -55,15 +55,24 @@ const FormularioParticipante = ({titulo, mensagemClica, regraFuncao, mostrar, se
 	}
 
 	function pegaRegioes(cards){
-		let regions = [];
+    let cardsPerRegion = {};
 		cards.forEach((card) => {
 			const region = card.faction.shortCode;
-			if (!regions.includes(factions[region])){
-				regions.push(factions[region]);
-			}
+      if (!cardsPerRegion.hasOwnProperty(region)){
+        cardsPerRegion[region] = 0
+      }
+      cardsPerRegion[region] = cardsPerRegion[region] += 1
 		});
-		regions.sort();
-		return regions;
+
+    let allRegions = Object.keys(cardsPerRegion).map((region) => [region, cardsPerRegion[region]]);
+		let deckRegions = allRegions
+      .sort((a,b) => (b[1] - a[1]))
+      .slice(0,2)
+      .map((region) => factions[region[0]]);
+ 
+    console.log(factions)
+
+		return deckRegions;
 	}
 
 	function pegaCampeoes(cards){
@@ -90,7 +99,8 @@ const FormularioParticipante = ({titulo, mensagemClica, regraFuncao, mostrar, se
 
 			try{
 				cards = DeckEncoder.decode(code);
-			}catch{
+			}catch (e){
+        console.log(e)
 				return undefined;
 			}
 


### PR DESCRIPTION
:us: Although the game have some formats that allow three regions (singleton).
The most played format is standard, which allows only two regions.

With the introduction of Bandle City and multiregion cards, we need to
filter which are the main regions of the deck.

To do this, the code counts how many cards each region have in the decks
and choose the two regions with more cards.

:brazil: Apesar do jogo permitir alguns formatos com três regioẽs, o formato mais jogado hoje é o padrão, que apenas permite que duas regiões nos decks.

Com a introdução de bandópolis e cartas multiregionais ao jogo, é necessário filtar quais são as regiões principais do deck.

Para isso, o código conta quantas cartas de cada região tem o deck e escolhe as duas regiões com mais cartas.